### PR TITLE
fix: favorite page image disable error

### DIFF
--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -16,16 +16,16 @@
         </div>
         <div class="w-full text-white text-xl flex justify-center items-center pt-5">{{ this.$store.state.favoriteGameRound }}</div>
       </div>
-      <div class="w-full h-full mt-2 flex justify-center relative min-w-min">
+      <div :class="{ 'click-disabled': this.isDisabled() == true }" class="w-full h-full mt-2 flex justify-center relative min-w-min">
         <div @click="selectedImg(0)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === 0 }" class="flex flex-col justify-center items-end cursor-pointer">
           <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === 0, 'unselected-left': this.$store.state.favoriteSelectedImg === 1 }" class="w-favorite-content-width h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 min-h-72 overflow-hidden">
-            <img @error="handleImageError($event)" class="object-cover w-full h-full bg-gray-200" :src="currentPair.image1" />
+            <img @error="handleImageError($event)" class="object-cover w-full h-full" :src="currentPair.image1" />
           </div>
           <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === 0, 'hidden': this.$store.state.favoriteSelectedImg === 1 }" class="flex items-center justify-center w-favorite-content-width text-white text-2xl mt-3 min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title1 }}</div>
         </div>
         <div @click="selectedImg(1)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === 1 }" class="flex flex-col justify-center cursor-pointer">
           <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === 1, 'unselected-right': this.$store.state.favoriteSelectedImg === 0 }" class="w-favorite-content-width h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 min-h-72 overflow-hidden">
-            <img @error="handleImageError($event)" class="object-cover w-full h-full bg-gray-200" :src="currentPair.image2" />
+            <img @error="handleImageError($event)" class="object-cover w-full h-full" :src="currentPair.image2" />
           </div>
           <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === 1, 'hidden': this.$store.state.favoriteSelectedImg === 0 }" class="flex items-center justify-center w-favorite-content-width text-white text-2xl mt-3 min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title2 }}</div>
           <div v-if="this.$store.state.favoriteSelectedImg == 0" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center pointer-events-none">
@@ -49,11 +49,6 @@ export default {
     this.$store.commit('resetFavoriteRoundFinish')
     this.$store.dispatch('getFavoriteData')
     this.$store.dispatch('setFavoriteRankMax')
-  },
-  data() {
-    return {
-      isError: false
-    }
   },
   methods: {
     handleImageError(event) {

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -151,7 +151,4 @@ export default {
 .click-disabled {
   pointer-events: none;
 }
-.click-abled {
-  pointer-events: auto;
-}
 </style>

--- a/src/store.js
+++ b/src/store.js
@@ -37,7 +37,7 @@ export default createStore({
     favoriteCurrentPairIndex: 0,
     favoriteSelectedPairs: [],
     favoriteRanksPerPage: 3,
-    favoriteImagePair: 2
+    favoriteImagePair: 2,
   },
   mutations: {
     handleMainActive(state, i) {
@@ -206,8 +206,8 @@ export default createStore({
       } else {
         finalPair = context.state.favoriteSelectedPairs
       }
-      context.commit('resetFavoriteSelectedImg')
 
+      context.dispatch('selectFavoriteImgIndex', -1)
       context.commit('updateFavoriteImagePairs', newPairs)
       context.commit('calculateGameRound')
 
@@ -292,7 +292,7 @@ export default createStore({
           })
         )
       })
-
+      
       context.dispatch('loadNextPairWithDelay')
     },
   }


### PR DESCRIPTION
## before
- favorite page에서 다음 라운드 넘어갈 때, 애니메이션은 이미지 선택될 때 그대로 유지됨

## after
- favorite page에서 다음 라운드 넘어갈 때, 애니메이션 원상 복귀

## problem
- favorite page에서 다음 라운드 넘어갈 때, 애니메이션이 복귀되면서 클릭 이벤트가 disabled가 적용 안됨

## resolve
- 로직 변경을 통해 해결