### PR TITLE
feat : make confirmation before delete comment

### DIFF
--- a/src/components/CommentPage.vue
+++ b/src/components/CommentPage.vue
@@ -30,7 +30,7 @@
             <div v-else>
               <div v-if="isMyComment[index]" class="flex gap-2 select-none">
                 <div class="text-primary text-base md:text-lg cursor-pointer" @click="updateComment(index)">수정</div>
-                <div class="text-quiz-box text-base md:text-lg cursor-pointer" @click="deleteComment(index)">삭제</div>
+                <div class="text-quiz-box text-base md:text-lg cursor-pointer" @click="confirmDelete(index)">삭제</div>
               </div>
             </div>
           </div>
@@ -226,6 +226,11 @@ export default {
     changeLastPage() {
       this.currentPage = this.pageCount
       this.getComment(this.currentPage - 1)
+    },
+    confirmDelete(index) {
+      if (confirm("댓글을 삭제하시겠습니까?")) {
+        this.deleteComment(index)
+      }
     },
     async deleteComment(index) {
       const formData = {


### PR DESCRIPTION
### issue
- 댓글 삭제를 누르면 확인 창 없이 바로 삭제가 되서 불편함

### solution
- 댓글 삭제 확인창을 만들어 확인을 누르면 삭제가 되도록 변경