### PR TITLE
feat: main, favorite, statistic page mobile responsive design and fix favorite page final round error

### DIFF
--- a/src/components/FavoriteFinishModal.vue
+++ b/src/components/FavoriteFinishModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full bg-modal-background bg-opacity-50 fixed flex justify-center items-center">
+  <div class="w-full h-full bg-modal-background bg-opacity-50 fixed flex justify-center items-center z-50">
     <div class="bg-white rounded-3xl">
       <div class="flex flex-col items-center py-4 sm:py-8 md:py-10 px-9 sm:px-20 md:px-24 sm:m-2 sm:border-3 md:border-4 border-favorite-theme rounded-3xl select-none">
         <div class="text-lg sm:text-xl md:text-2xl font-extrabold text-primary py-1 sm:py-2 md:py-3">고냥이 월드컵</div>

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -4,34 +4,34 @@
       <FinishModal v-if="this.$store.state.favoriteRoundFinish"></FinishModal>
     </Transition>
     <div class="flex flex-col h-screen w-full bg-primary select-none">
-      <div class="w-full h-24 flex items-center">
+      <div class="w-full h-24 flex items-center pt-4">
         <div @click="handleRouterMain()" class="text-white text-xl pl-6 font-semibold hover:cursor-pointer min-w-40">PLAY - TINO</div>
       </div>
-      <div class="w-full sm:min-h-32 flex flex-col justify-end pt-16">
-        <div class="w-full h-24 flex justify-center items-center">
-          <div class="flex items-baseline min-w-52">
+      <div class="w-full sm:min-h-32 flex flex-col justify-end pt-20 md:pt-16">
+        <div class="w-full h-16 md:h-24 flex justify-center items-center">
+          <div class="flex justify-center items-baseline min-w-52">
             <div class="text-4xl md:text-5xl lg:text-7xl text-favorite-theme font-extrabold text-outline">고냥이</div>
             <div class="text-xl md:text-2xl lg:text-4xl text-white font-bold">월드컵!</div>
           </div>
         </div>
-        <div class="w-full text-white text-xl flex justify-center items-center pt-5">{{ this.$store.state.favoriteGameRound }}</div>
+        <div class="w-full text-white text-sm pb-4 md:text-xl flex justify-center items-center md:pt-5">{{ this.$store.state.favoriteGameRound }}</div>
       </div>
-      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-full mt-2 flex justify-center relative min-w-min">
-        <div @click="selectImage(this.imageIndex.left)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex flex-col justify-center items-end cursor-pointer">
-          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-favorite-content-width h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 min-h-72 overflow-hidden">
+      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto md:h-full mt-2 flex justify-center relative md:min-w-min">
+        <div @click="selectImage(this.imageIndex.left)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex flex-col md:justify-center items-center cursor-pointer">
+          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-40 h-40 md:w-favorite-content-width md:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.left]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.left]" @load="handleImageLoad(this.imageIndex.left)" @error="handleImageError(this.imageIndex.left)" class="object-cover w-full h-full" :src="currentPair.image1" />
           </div>
-          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex items-center justify-center w-favorite-content-width text-white text-2xl mt-3 min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title1 }}</div>
+          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex text-xs items-center justify-center md:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title1 }}</div>
         </div>
-        <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col justify-center cursor-pointer">
-          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-favorite-content-width h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 min-h-72 overflow-hidden">
+        <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col md:justify-center cursor-pointer">
+          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-40 h-40 md:w-favorite-content-width md:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.right]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.right]" @load="handleImageLoad(this.imageIndex.right)" @error="handleImageError(this.imageIndex.right)" class="object-cover w-full h-full" :src="currentPair.image2" />
           </div>
-          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex items-center justify-center w-favorite-content-width text-white text-2xl mt-3 min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title2 }}</div>
+          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex text-xs items-center justify-center md:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 md:text-2xl selected-text-outline">{{ currentPair.title2 }}</div>
           <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center pointer-events-none">
-            <img class="w-24 h-24 sm:-translate-y-18" src="/image/vs.png" />
+            <img class="w-8 h-8 md:w-24 md:h-24 sm:-translate-y-18" src="/image/vs.png" />
           </div>
         </div>
       </div>

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -16,22 +16,22 @@
         </div>
         <div class="w-full text-white text-sm pb-4 md:text-xl flex justify-center items-center md:pt-5">{{ this.$store.state.favoriteGameRound }}</div>
       </div>
-      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto lg:h-full mt-2 flex justify-center relative">
+      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto xl:h-full mt-2 flex justify-center relative min-w-50">
         <div @click="selectImage(this.imageIndex.left)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex flex-col lg:justify-center items-center cursor-pointer">
-          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
+          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-44 h-44 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.left]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.left]" @load="handleImageLoad(this.imageIndex.left)" @error="handleImageError(this.imageIndex.left)" class="object-cover w-full h-full" :src="currentPair.image1" />
           </div>
-          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title1 }}</div>
+          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title1 }}</div>
         </div>
         <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col lg:justify-center cursor-pointer">
-          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
+          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-44 h-44 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.right]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.right]" @load="handleImageLoad(this.imageIndex.right)" @error="handleImageError(this.imageIndex.right)" class="object-cover w-full h-full" :src="currentPair.image2" />
           </div>
-          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title2 }}</div>
-          <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center  pointer-events-none">
-            <img class="w-8 h-8 sm:w-20 sm:h-20 md:w-24 md:h-24 lg:w-24 lg:h-24 sm:-translate-y-18" src="/image/vs.png" />
+          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg md:text-md lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title2 }}</div>
+          <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center pointer-events-none">
+            <img class="w-8 h-8 sm:w-16 sm:h-16 md:w-16 md:h-16 lg:w-20 lg:h-20 sm:-translate-y-18" src="/image/vs.png" />
           </div>
         </div>
       </div>
@@ -142,7 +142,6 @@ export default {
 }
 .selected-left {
   transition: transform 0.5s ease, left 0.5s ease;
-  transform: scale(1.1);
   transform: translateX(25%);
   z-index: 40;
 }
@@ -150,19 +149,16 @@ export default {
   transition: transform 0.5s ease;
   transform: translate(25%, -350%);
   z-index: 50;
-  font-weight: 700;
   font-size: 2rem;
 }
 .selected-right {
   transition: transform 0.5s ease, right 0.5s ease;
-  transform: scale(1.1);
   transform: translateX(-25%);
 }
 .selected-right-text {
   transition: transform 0.5s ease;
   transform: translate(-25%, -350%);
   z-index: 50;
-  font-weight: 700;
   font-size: 2rem;
 }
 .hidden {

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -5,7 +5,7 @@
     </Transition>
     <div class="flex flex-col h-screen w-full bg-primary select-none">
       <div class="w-full h-24 flex items-center pt-4">
-        <div @click="handleRouterMain()" class="text-white text-xl pl-6 font-semibold hover:cursor-pointer min-w-40">PLAY - TINO</div>
+        <div @click="handleRouterMain()" class="text-white text-md md:text-xl pl-6 font-semibold hover:cursor-pointer min-w-40">PLAY - TINO</div>
       </div>
       <div class="w-full sm:min-h-32 flex flex-col justify-end pt-20 md:pt-16">
         <div class="w-full h-16 md:h-24 flex justify-center items-center">

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -16,20 +16,20 @@
         </div>
         <div class="w-full text-white text-sm pb-4 md:text-xl flex justify-center items-center md:pt-5">{{ this.$store.state.favoriteGameRound }}</div>
       </div>
-      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto xl:h-full mt-2 flex justify-center relative min-w-50">
+      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto xl:h-full mt-2 mb-5 flex justify-center relative min-w-50">
         <div @click="selectImage(this.imageIndex.left)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex flex-col lg:justify-center items-center cursor-pointer">
-          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-44 h-44 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
+          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.left]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.left]" @load="handleImageLoad(this.imageIndex.left)" @error="handleImageError(this.imageIndex.left)" class="object-cover w-full h-full" :src="currentPair.image1" />
           </div>
-          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title1 }}</div>
+          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title1 }}</div>
         </div>
         <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col lg:justify-center cursor-pointer">
-          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-44 h-44 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
+          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.right]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.right]" @load="handleImageLoad(this.imageIndex.right)" @error="handleImageError(this.imageIndex.right)" class="object-cover w-full h-full" :src="currentPair.image2" />
           </div>
-          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg md:text-md lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title2 }}</div>
+          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg md:text-md lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title2 }}</div>
           <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center pointer-events-none">
             <img class="w-8 h-8 sm:w-16 sm:h-16 md:w-16 md:h-16 lg:w-20 lg:h-20 sm:-translate-y-18" src="/image/vs.png" />
           </div>
@@ -146,20 +146,22 @@ export default {
   z-index: 40;
 }
 .selected-left-text {
+  font-size: 0.825rem;
   transition: transform 0.5s ease;
   transform: translate(25%, -350%);
   z-index: 50;
-  font-size: 2rem;
+  font-weight: 700;
 }
 .selected-right {
   transition: transform 0.5s ease, right 0.5s ease;
   transform: translateX(-25%);
 }
 .selected-right-text {
+  font-size: 0.825rem;
   transition: transform 0.5s ease;
   transform: translate(-25%, -350%);
   z-index: 50;
-  font-size: 2rem;
+  font-weight: 700;
 }
 .hidden {
   opacity: 0;
@@ -193,4 +195,41 @@ export default {
     background-color: #e0e0e0;
   }
 }
+@media (min-width: 640px) {
+  .selected-left-text {
+    font-size: 1rem;
+    transition: transform 0.5s ease;
+    transform: translate(45%, -350%);
+  }
+  .selected-right-text {
+    font-size: 1rem;
+    transition: transform 0.5s ease;
+    transform: translate(-25%, -350%);
+  }
+} 
+@media (min-width: 768px) {
+  .selected-left-text {
+    font-size: 1.25rem;
+    transition: transform 0.5s ease;
+    transform: translate(25%, -350%);
+  }
+  .selected-right-text {
+    font-size: 1.25rem;
+    transition: transform 0.5s ease;
+    transform: translate(-25%, -350%);
+  }
+}
+@media (min-width: 1024px) {
+  .selected-left-text {
+    font-size: 1.75rem;
+    transition: transform 0.5s ease;
+    transform: translate(25%, -350%);
+  }
+  .selected-right-text {
+    font-size: 1.75rem;
+    transition: transform 0.5s ease;
+    transform: translate(-25%, -350%);
+  }
+}
 </style>
+// 내가 보기엔 ! 최소값을 기본 애니메이션으로 지정한 후에, 나머지를 media 사용해서 하는 게 맞는 거 같군!

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -10,7 +10,7 @@
       <div class="w-full sm:min-h-32 flex flex-col justify-end pt-20 md:pt-16">
         <div class="w-full h-16 md:h-24 flex justify-center items-center">
           <div class="flex justify-center items-baseline min-w-52">
-            <div class="text-4xl md:text-5xl lg:text-7xl text-favorite-theme font-extrabold text-outline">고냥이</div>
+            <div class="text-3xl sm:text-4xl md:text-5xl lg:text-7xl text-favorite-theme font-extrabold text-outline">고냥이</div>
             <div class="text-xl md:text-2xl lg:text-4xl text-white font-bold">월드컵!</div>
           </div>
         </div>
@@ -22,14 +22,14 @@
             <div v-if="!imagePair[this.imageIndex.left]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.left]" @load="handleImageLoad(this.imageIndex.left)" @error="handleImageError(this.imageIndex.left)" class="object-cover w-full h-full" :src="currentPair.image1" />
           </div>
-          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title1 }}</div>
+          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-favortire-default-title sm:text-sm mt-1 md:mt-3 md:text-lg lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title1 }}</div>
         </div>
         <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col lg:justify-center cursor-pointer">
           <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.right]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.right]" @load="handleImageLoad(this.imageIndex.right)" @error="handleImageError(this.imageIndex.right)" class="object-cover w-full h-full" :src="currentPair.image2" />
           </div>
-          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-xs sm:text-sm mt-1 md:mt-3 md:text-lg md:text-md lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title2 }}</div>
+          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex items-center justify-center xl:w-favorite-content-width text-white min-w-40 text-favortire-default-title sm:text-sm mt-1 md:mt-3 md:text-lg md:text-md lg:text-xl xl:text-2xl md:min-w-72 selected-text-outline">{{ currentPair.title2 }}</div>
           <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center pointer-events-none">
             <img class="w-8 h-8 sm:w-16 sm:h-16 md:w-16 md:h-16 lg:w-20 lg:h-20 sm:-translate-y-18" src="/image/vs.png" />
           </div>

--- a/src/components/FavoritePage.vue
+++ b/src/components/FavoritePage.vue
@@ -16,22 +16,22 @@
         </div>
         <div class="w-full text-white text-sm pb-4 md:text-xl flex justify-center items-center md:pt-5">{{ this.$store.state.favoriteGameRound }}</div>
       </div>
-      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto md:h-full mt-2 flex justify-center relative md:min-w-min">
-        <div @click="selectImage(this.imageIndex.left)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex flex-col md:justify-center items-center cursor-pointer">
-          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-40 h-40 md:w-favorite-content-width md:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
+      <div :class="{ 'click-disabled': isDisabled() }" class="w-full h-auto lg:h-full mt-2 flex justify-center relative">
+        <div @click="selectImage(this.imageIndex.left)" :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex flex-col lg:justify-center items-center cursor-pointer">
+          <div :class="{ 'selected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'unselected-left': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.left]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.left]" @load="handleImageLoad(this.imageIndex.left)" @error="handleImageError(this.imageIndex.left)" class="object-cover w-full h-full" :src="currentPair.image1" />
           </div>
-          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex text-xs items-center justify-center md:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title1 }}</div>
+          <div :class="{ 'selected-left-text': this.$store.state.favoriteSelectedImg === this.imageIndex.left, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title1 }}</div>
         </div>
-        <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col md:justify-center cursor-pointer">
-          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-40 h-40 md:w-favorite-content-width md:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
+        <div @click="selectImage(this.imageIndex.right)" :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right }" class="flex flex-col lg:justify-center cursor-pointer">
+          <div :class="{ 'selected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'unselected-right': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="w-40 h-40 xl:w-favorite-content-width xl:h-favorite-content-height aspect-w-1 aspect-h-1 border-8 cursor-pointer sm:min-w-72 sm:min-h-72 overflow-hidden">
             <div v-if="!imagePair[this.imageIndex.right]" class="skeleton-loader"></div>
             <img v-show="imagePair[this.imageIndex.right]" @load="handleImageLoad(this.imageIndex.right)" @error="handleImageError(this.imageIndex.right)" class="object-cover w-full h-full" :src="currentPair.image2" />
           </div>
-          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex text-xs items-center justify-center md:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 md:text-2xl selected-text-outline">{{ currentPair.title2 }}</div>
-          <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center pointer-events-none">
-            <img class="w-8 h-8 md:w-24 md:h-24 sm:-translate-y-18" src="/image/vs.png" />
+          <div :class="{ 'selected-right-text': this.$store.state.favoriteSelectedImg === this.imageIndex.right, 'hidden': this.$store.state.favoriteSelectedImg === this.imageIndex.left }" class="flex text-xs items-center justify-center xl:w-favorite-content-width text-white text-2xl mt-1 md:mt-3 md:min-w-72 sm:text-2xl selected-text-outline">{{ currentPair.title2 }}</div>
+          <div v-if="this.$store.state.favoriteSelectedImg === ''" class="absolute top-0 bottom-0 left-0 right-0 flex items-center justify-center  pointer-events-none">
+            <img class="w-8 h-8 sm:w-20 sm:h-20 md:w-24 md:h-24 lg:w-24 lg:h-24 sm:-translate-y-18" src="/image/vs.png" />
           </div>
         </div>
       </div>

--- a/src/components/FavoriteStatisticPage.vue
+++ b/src/components/FavoriteStatisticPage.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center pr-0 md:pr-4">
     <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
+      <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="w-full bg-primary flex flex-col select-none">
     <div class="w-full h-14 min-h-8 flex items-center">

--- a/src/components/FavoriteStatisticPage.vue
+++ b/src/components/FavoriteStatisticPage.vue
@@ -4,7 +4,7 @@
     <div class="flex justify-center select-none">
       <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
+    <div class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="w-full bg-primary flex flex-col select-none">
     <div class="w-full h-14 min-h-8 flex items-center">

--- a/src/components/FavoriteStatisticPage.vue
+++ b/src/components/FavoriteStatisticPage.vue
@@ -7,23 +7,21 @@
     <div class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="w-full bg-primary flex flex-col select-none">
-    <div class="w-full h-14 min-h-8 flex items-center">
-      <div class="text-white text-xl pl-4">고냥이 월드컵</div>
+    <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">
+      <div class="text-white text-sm pl-4 min-w-36 md:text-xl">고냥이 월드컵</div>
     </div>
     <div class="w-full h-auto flex flex-col justify-center pt-8 pb-8 bg-white">
       <div v-for="(rank, i) in 3" :key="i" class="flex justify-center pb-8">
-        <div class="w-3/4 flex justify-around items-center">
-          <div :class="getRankColor(getRank(i))" class="w-16 h-16 flex justify-center items-center p-4 text-light-purple text-4xl font-bold">{{ getRank(i) }}</div>
-          
-          <div class="relative w-48 h-48 border-5 border-light-purple bg-light-purple">
+        <div class="w-full flex justify-center items-center">
+          <div :class="getRankColor(getRank(i))" class="w-1/12 min-w-4 flex justify-center px-0 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">{{ getRank(i) }}</div>
+          <div class="relative w-14 h-14 min-w-14 min-h-14 sm:w-24 sm:h-24 md:w-36 md:h-36 lg:w-40 lg:w-40 xl:w-48 xl:h-48 border-5 border-light-purple bg-light-purple">
             <div v-if="!loading[i]" class="skeleton-loader"></div>
             <img v-else @error="handleImageError($event)" :src="this.$store.state.favoriteRankData[i]?.favoriteImage ?? ''" @load="loading[i]" class="w-full h-full object-cover" />
           </div>
-          
-          <div class="w-1/4 flex justify-center text-primary text-2xl">{{ this.$store.state.favoriteRankData[i]?.favoriteTitle ?? 'Now Loading...' }}</div>
-          <div class="w-1/3 flex justify-center">
-            <div class="w-72 bg-gray-300 rounded-xl">
-              <div class="p-3 bg-light-purple text-xl font-medium text-primary text-center leading-none rounded-xl flex" :style="{ width: $store.state.favoriteRankData[i]?.favoriteRankPercentage < 2 ? '1.5rem' : $store.state.favoriteRankData[i]?.favoriteRankPercentage + '%' }">{{ this.$store.state.favoriteRankData[i]?.favoriteRankPercentage.toFixed(2) }}%</div>
+          <div class="w-1/4 min-w-32 flex justify-center text-primary text-xs sm:text-lg md:text-lg lg:text-xl xl:text-2xl">{{ this.$store.state.favoriteRankData[i]?.favoriteTitle ?? 'Now Loading...' }}</div>
+          <div class="w-1/4 min-w-32 flex justify-center">
+            <div class="w-28 h-5 sm:h-8 sm:w-36 md:h-10 md:w-48 lg:h-11 lg:w-64 xl:w-72 bg-gray-300 rounded-xl">
+              <div class="flex items-center pl-2 bg-light-purple text-xs h-5 sm:h-8 sm:text-sm md:h-10 md:text-md lg:h-11 lg:text-lg xl:text-xl font-medium text-primary text-center leading-none rounded-xl flex" :style="{ width: $store.state.favoriteRankData[i]?.favoriteRankPercentage < 2 ? '1.5rem' : $store.state.favoriteRankData[i]?.favoriteRankPercentage + '%' }">{{ this.$store.state.favoriteRankData[i]?.favoriteRankPercentage.toFixed(2) }}%</div>
             </div>
           </div>
         </div>

--- a/src/components/FavoriteStatisticPage.vue
+++ b/src/components/FavoriteStatisticPage.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex w-full h-24 bg-white justify-between items-center select-none">
-    <div class="w-30 h-20 ml-20"></div>
-    <div class="flex justify-center">
-      <img @click="handleRouterMain()" src="/image/logo.png" class="w-30 h-20 cursor-pointer" />
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
+    <div class="w-30 h-10 ml-20"></div>
+    <div class="flex justify-center select-none">
+      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer">Login</div>
+    <div class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="w-full bg-primary flex flex-col select-none">
     <div class="w-full h-14 min-h-8 flex items-center">

--- a/src/components/FavoriteStatisticPage.vue
+++ b/src/components/FavoriteStatisticPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex w-full h-24 bg-white justify-between items-center select-none">
-    <div class="w-30 h-20 ml-10"></div>
+    <div class="w-30 h-20 ml-20"></div>
     <div class="flex justify-center">
       <img @click="handleRouterMain()" src="/image/logo.png" class="w-30 h-20 cursor-pointer" />
     </div>

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -22,26 +22,21 @@
         :key="i"
         :style="`background-image: url(${game.image});`"
         role="button"
-        :class="this.$store.state.MainActive === i ? 'active' : ''"
-        @mouseover="this.$store.commit('handleMainActive', i)"
-        @click="
-          this.$store.state.MainActive === i
-            ? handleRouterLink(i)
-            : this.$store.commit('handleMainActive', i)
-        "
+        :class="isMobile ? beforeDestroy() : $store.state.MainActive === i ? 'active' : ''"
+        @mouseover="!isMobile && $store.commit('handleMainActive', i)"
       >
         <div
           :class="
-            this.$store.state.MainActive === i
+            $store.state.MainActive === i
               ? 'title-default'
               : 'select-title'
           "
-          class="flex p-10 min-w-72"
+          class="flex flex-col justify-end p-10 min-w-72 h-full bg-opacity-50"
         >
           <h3 class="text-xl md:text-3xl font-bold">{{ game.name }}</h3>
           <div
-            :class="this.$store.state.MainActive === i ? '' : 'section-content'"
-            @click="this.$store.commit('handleMainActive', i)"
+            :class="[$store.state.MainActive === i ? '' : 'section-content', isMobile ? 'show-subtitle' : '']"
+            @click="$store.commit('handleMainActive', i)"
             class="min-w-56"
           >
             <p class="text-sm md:text-md">
@@ -59,16 +54,16 @@
       How can use?
     </div>
     <div class="w-full text-primary flex justify-evenly">
-      <ul class="pr-4 pl-4 w-96 w-min-96 sm:w-96 md:w-5/6 md:pt-8 flex flex-col justify-evenly items-start sm:flex-col md:flex-row lg:flex-row">
+      <ul class="pr-4 pl-4 w-96 w-min-96 sm:w-96 md:w-5/6 md:pt-8 flex flex-col justify-evenly items-center sm:items-center sm:flex-col md:items-center md:flex-row lg:items-start lg:flex-row">
         <li
-          v-for="(game, i) in this.$store.state.MainGameData"
+          v-for="(game, i) in $store.state.MainGameData"
           :key="i"
           class="flex flex-col align-center justify-center md:w-96 pr-4 pl-4"
         >
           <h2 class="flex justify-center font-bold text-primary text-2xl pb-7">
             {{ game.name }} 
           </h2>
-          <p class="text-xl h-auto pb-8 md:h-72 md:w-full lg:h-48">{{ game.rule }}</p>
+          <p class="text-md w-72 h-auto pb-8 md:text-xl md:h-72 md:w-full lg:h-48">{{ game.rule }}</p>
           <div class="flex justify-center pb-16 md:pb-0">
             <div @click="handlerouterLinkStatistic(i)" class="w-32 h-10 flex justify-center items-center rounded-full bg-light-purple text-white text-lg hover:cursor-pointer hover:brightness-125">
               Statistic
@@ -82,7 +77,7 @@
     class="bg-primary h-full p-10 pb-0 flex flex-col justify-around items-center select-none md:flex-row md:h-48"
   >
     <div
-      v-for="(menu, i) in this.$store.state.footerMenu"
+      v-for="(menu, i) in $store.state.footerMenu"
       :key="i"
       class="w-48 pb-10 flex flex-col justify-start"
     >
@@ -95,7 +90,9 @@
 <script>
 export default {
   data() {
-    return {}
+    return {
+      isMobile: window.innerWidth <= 768
+    }
   },
   methods: {
     handleRouterLink(i) {
@@ -134,6 +131,12 @@ export default {
           "https://accounts.google.com/o/oauth2/auth?client_id=461061717960-3qjph66sbpc88fte75el297ca14ht30t.apps.googleusercontent.com&redirect_uri=https://api.favorite.play-tino.com/login/oauth2/code/google&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
       }
     },
+    handleResize() {
+      this.isMobile = window.innerWidth <= 768
+    },
+    beforeDestroy() {
+      window.removeEventListener('resize', this.handleResize)
+    }
   },
   mounted() {
     const user = this.$route.query.userId
@@ -145,7 +148,17 @@ export default {
       this.$store.commit("setUserId", user)
       this.$router.push("/")
     }
+    window.addEventListener('resize', this.handleResize)
   },
+  watch: {
+    isMobile() {
+      if(window.innerWidth <= 768) {
+        return this.isMobile;
+      } else {
+        return !this.isMobile;
+      }
+    }
+  }
 }
 </script>
 
@@ -213,5 +226,14 @@ export default {
 }
 #game-list.active .section-content .inner {
   opacity: 1;
+}
+.show-subtitle {
+  opacity: 1 !important;
+}
+@media (max-width: 768px) {
+  #game-list {
+    height: 200px;
+    flex-direction: column;
+  }
 }
 </style>

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -2,7 +2,7 @@
   <div
     class="flex w-full h-24 bg-white justify-between items-center select-none"
   >
-    <div class="w-30 h-20 ml-10"></div>
+    <div class="w-30 h-20 ml-20"></div>
     <div class="flex justify-center">
       <img src="/image/logo.png" class="w-30 h-20" />
     </div>
@@ -17,9 +17,10 @@
     Games
   </div>
   <div class="bg-primary w-full h-[calc(100svh-9rem)] select-none">
-    <ul class="flex w-full h-full overflow-hidden">
+    <ul class="flex flex-col w-full h-full overflow-hidden sm:flex-row md:flex-row lg:flex-row">
       <li
         id="game-list"
+        class=""
         v-for="(game, i) in this.$store.state.MainGameData"
         :key="i"
         :style="`background-image: url(${game.image});`"
@@ -38,6 +39,7 @@
               ? 'title-default'
               : 'select-title'
           "
+          class="flex"
         >
           <h3 class="text-3xl font-bold">{{ game.name }}</h3>
           <div
@@ -52,24 +54,24 @@
       </li>
     </ul>
   </div>
-  <div class="pb-20 pt-20 select-none">
+  <div class="pt-20 select-none md:pb-20">
     <div
       class="flex text-light-purple font-semibold text-4xl justify-center pb-8"
     >
       How can use?
     </div>
     <div class="w-full text-primary flex justify-evenly">
-      <ul class="w-5/6 pt-8 flex justify-evenly items-start">
+      <ul class="pr-4 pl-4 md:w-5/6 md:pt-8 flex flex-col justify-evenly items-center sm:flex-row md:flex-row lg:flex-row">
         <li
           v-for="(game, i) in this.$store.state.MainGameData"
           :key="i"
-          class="w-96 pr-4 pl-4"
+          class="flex flex-col align-center justify-center md:w-96 pr-4 pl-4"
         >
           <h2 class="flex justify-center font-bold text-primary text-2xl pb-7">
             {{ game.name }} 
           </h2>
-          <p class="text-xl min-h-40 pb-7">{{ game.rule }}</p>
-          <div class="flex justify-center">
+          <p class="text-xl h-auto pb-8 md:min-h-40">{{ game.rule }}</p>
+          <div class="flex justify-center pb-16 md:pb-0">
             <div @click="handlerouterLinkStatistic(i)" class="w-32 h-10 flex justify-center items-center rounded-full bg-light-purple text-white text-lg hover:cursor-pointer hover:brightness-125">
               Statistic
             </div>
@@ -79,12 +81,12 @@
     </div>
   </div>
   <div
-    class="bg-primary h-64 p-10 flex flex-row justify-around items-center select-none"
+    class="bg-primary h-full p-10 pb-0 flex flex-col justify-around items-center select-none md:flex-row md:h-48"
   >
     <div
       v-for="(menu, i) in this.$store.state.footerMenu"
       :key="i"
-      class="w-48"
+      class="w-48 pb-10 flex flex-col justify-start"
     >
       <div class="text-white text-xl font-medium mb-3">{{ menu }}</div>
       <div class="text-white font-medium">{{ menu }}</div>

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -1,13 +1,11 @@
 <template>
-  <div
-    class="flex w-full h-24 bg-white justify-between items-center select-none"
-  >
-    <div class="w-30 h-20 ml-20"></div>
-    <div class="flex justify-center">
-      <img src="/image/logo.png" class="w-30 h-20" />
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center select-none">
+    <div class="w-30 ml-20"></div>
+    <div class="flex justify-center select-none">
+      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" />
     </div>
     <div
-      class="text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer"
+      class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer"
       @click="handleClickLogin()"
     >
       {{ this.$store.state.userId !== "" ? "Logout" : "Login" }}

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -11,14 +11,13 @@
       {{ this.$store.state.userId !== "" ? "Logout" : "Login" }}
     </div>
   </div>
-  <div class="w-full bg-primary text-white p-4 font-medium select-none">
+  <div class="w-full bg-primary text-white p-3 text-sm md:p-4 md:text-xl font-medium select-none">
     Games
   </div>
   <div class="bg-primary w-full h-[calc(100svh-9rem)] select-none">
-    <ul class="flex flex-col w-full h-full overflow-hidden sm:flex-row md:flex-row lg:flex-row">
+    <ul class="flex flex-col w-full h-full overflow-hidden sm:flex-col md:flex-col lg:flex-col xl:flex-row">
       <li
         id="game-list"
-        class=""
         v-for="(game, i) in this.$store.state.MainGameData"
         :key="i"
         :style="`background-image: url(${game.image});`"
@@ -37,14 +36,15 @@
               ? 'title-default'
               : 'select-title'
           "
-          class="flex"
+          class="flex p-10 min-w-72"
         >
-          <h3 class="text-3xl font-bold">{{ game.name }}</h3>
+          <h3 class="text-xl md:text-3xl font-bold">{{ game.name }}</h3>
           <div
             :class="this.$store.state.MainActive === i ? '' : 'section-content'"
             @click="this.$store.commit('handleMainActive', i)"
+            class="min-w-56"
           >
-            <p>
+            <p class="text-sm md:text-md">
               {{ game.subtitle }}
             </p>
           </div>
@@ -54,12 +54,12 @@
   </div>
   <div class="pt-20 select-none md:pb-20">
     <div
-      class="flex text-light-purple font-semibold text-4xl justify-center pb-8"
+      class="flex text-light-purple font-semibold text-3xl sm:text-3xl md:text-3xl lg:text-4xl xl:text-4xl justify-center pb-8"
     >
       How can use?
     </div>
     <div class="w-full text-primary flex justify-evenly">
-      <ul class="pr-4 pl-4 md:w-5/6 md:pt-8 flex flex-col justify-evenly items-center sm:flex-row md:flex-row lg:flex-row">
+      <ul class="pr-4 pl-4 w-96 w-min-96 sm:w-96 md:w-5/6 md:pt-8 flex flex-col justify-evenly items-start sm:flex-col md:flex-row lg:flex-row">
         <li
           v-for="(game, i) in this.$store.state.MainGameData"
           :key="i"
@@ -68,7 +68,7 @@
           <h2 class="flex justify-center font-bold text-primary text-2xl pb-7">
             {{ game.name }} 
           </h2>
-          <p class="text-xl h-auto pb-8 md:min-h-40">{{ game.rule }}</p>
+          <p class="text-xl h-auto pb-8 md:h-72 md:w-full lg:h-48">{{ game.rule }}</p>
           <div class="flex justify-center pb-16 md:pb-0">
             <div @click="handlerouterLinkStatistic(i)" class="w-32 h-10 flex justify-center items-center rounded-full bg-light-purple text-white text-lg hover:cursor-pointer hover:brightness-125">
               Statistic
@@ -165,7 +165,6 @@ export default {
   justify-content: flex-end;
   align-content: flex-start;
   z-index: 20;
-  padding: 4rem;
 }
 #game-list {
   flex: 1;

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center select-none">
-    <div class="w-30 ml-20"></div>
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center pr-0 md:pr-4">
+    <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" />
+      <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" />
     </div>
     <div
-      class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer"
+      class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none"
       @click="handleClickLogin()"
     >
       {{ this.$store.state.userId !== "" ? "Logout" : "Login" }}

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -24,6 +24,11 @@
         role="button"
         :class="isMobile ? beforeDestroy() : $store.state.MainActive === i ? 'active' : ''"
         @mouseover="!isMobile && $store.commit('handleMainActive', i)"
+        @click="
+          this.$store.state.MainActive === i
+            ? handleRouterLink(i)
+            : this.$store.commit('handleMainActive', i)
+        "
       >
         <div
           :class="

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -5,7 +5,7 @@
       <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" />
     </div>
     <div
-      class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none"
+      class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none"
       @click="handleClickLogin()"
     >
       {{ this.$store.state.userId !== "" ? "Logout" : "Login" }}

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -1,31 +1,31 @@
 <template>
-  <div class="flex w-full h-24 bg-white justify-between items-center">
-    <div class="w-30 h-20 ml-20"></div>
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
+    <div class="w-30 sm:h-20 ml-20"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-20 cursor-pointer" @click="handleRouterMain()"/>
+      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="text-xs text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
-    <div class="w-full h-14 min-h-8 flex items-center select-none">
-      <div class="text-white text-xl pl-4 min-w-36">문제를 맞춰라</div>
+    <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">
+      <div class="text-white text-sm pl-4 min-w-36 md:text-xl">문제를 맞춰라</div>
     </div>
-    <div class="w-full h-auto bg-white pt-10 pb-3">
+    <div class="w-full h-auto bg-white pt-4 md:pt-10 pb-3">
       <div class="flex pb-2 sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
-        <div class="w-2/12 min-w-10 px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20"></div>
-        <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-3/12 items-center min-w-40 pl-2 select-none">닉네임</div>
-        <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-4/12 flex justify-center items-center min-w-48 select-none">맞춘 문제</div>
-        <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">총점</div>
+        <div class="md:w-2/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none text-white">0</div>
+        <div class="w-3/12 flex justify-center text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center sm:min-w-40 select-none pl-1">닉네임</div>
+        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-40 flex justify-center items-center sm:min-w-48 select-none">맞춘 문제</div>
+        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">총점</div>
       </div>
       <div v-for="(user, index) in this.rankData" :key="user.quizRankId">
         <div class="flex pb-4 md:pb-7">
-          <div class="w-2/12 min-w-10 flex justify-end px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
+          <div class="w-10 sm:min-w-10 flex justify-center pl-2 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
             <div :class=this.rankColor(this.getRank(index))>
               {{ this.getRank(index) }}
             </div>
           </div>
-          <div class="w-3/12 min-w-40 items-center pl-1 text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
-          <div class="w-4/12 min-w-48 flex gap-2 justify-center text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
+          <div class="w-3/12 flex justify-center sm:min-w-40 items-center pl-1 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
+          <div class="w-40 sm:min-w-48 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
             <div class="flex gap-2 select-none">
               <div>넌센스</div>
               <div class="flex">
@@ -42,7 +42,7 @@
               </div>
             </div>
           </div>
-          <div class="w-2/12 flex justify-center items-center text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl min-w-16 gap-1 select-none">
+          <div class="w-2/12 flex justify-center items-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl min-w-16 gap-1 select-none">
             <div>{{ user.allCorrect }}</div>
             <div>/</div>
             <div>10</div>
@@ -50,20 +50,20 @@
         </div>
       </div>
       <div class="select-none flex items-center justify-center text-sm md:text-lg lg:text-xl">
-        <font-awesome-icon class="text-primary text-base px-1 font-bold cursor-pointer" :icon="['fas', 'angle-double-left']" @click="changeFirstPage()"/>
-        <font-awesome-icon class="text-primary text-base pr-2 pl-1 font-bold cursor-pointer" :icon="['fas', 'angle-left']" @click="decressePageNumber()"/>
-        <div v-if="showStartEllipsis" class="text-primary px-2 font-bold text-base cursor-pointer" @click="changeFirstPage()">1</div>
-        <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-base">...</div>
+        <font-awesome-icon class="svg-inline--fa fa-angles-left text-primary text-xs sm:text-base px-1 font-bold cursor-pointer" :icon="['fas', 'angle-double-left']" @click="changeFirstPage()"/>
+        <font-awesome-icon class="svg-inline--fa fa-angle-left text-primary text-xs sm:text-base pr-2 pl-1 font-bold cursor-pointer" :icon="['fas', 'angle-left']" @click="decressePageNumber()"/>
+        <div v-if="showStartEllipsis" class="text-white w-4 h-4 sm:w-7 sm:h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changeFirstPage()">1</div>
+        <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-xs sm:text-base">...</div>
         <div v-for="(page, index) in pages" :key="index">
-          <div class="text-white w-7 h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-base cursor-pointer" @click="changePage(page)">
+          <div class="text-white w-4 h-4 sm:w-7 sm:h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changePage(page)">
             <div class="text-primary font-bold bg-white w-7 h-7 flex justify-center items-center" v-if="currentPage != page">{{ page }}</div>
             <div v-else>{{ page }}</div>
           </div>
         </div>
-        <div v-if="showEndEllipsis" class="text-primary font-bold px-1 text-base">...</div>
-        <div v-if="showEndEllipsis" class="text-primary font-bold px-2 text-base cursor-pointer" @click="changeLastPage()">{{ this.pageCount }}</div>
-        <font-awesome-icon class="text-primary font-bold text-base pr-1 pl-2 cursor-pointer" :icon="['fas', 'angle-right']" @click="increasePageNumber()"/>
-        <font-awesome-icon class="text-primary font-bold text-base px-1 cursor-pointer" :icon="['fas', 'angle-double-right']" @click="changeLastPage()"/>
+        <div v-if="showEndEllipsis" class="text-primary font-bold px-1 text-xs sm:text-base">...</div>
+        <div v-if="showEndEllipsis" class="text-primary font-bold px-2 text-xs sm:text-base cursor-pointer" @click="changeLastPage()">{{ this.pageCount }}</div>
+        <font-awesome-icon class="text-primary font-bold text-xs sm:text-base pr-1 pl-2 cursor-pointer" :icon="['fas', 'angle-right']" @click="increasePageNumber()"/>
+        <font-awesome-icon class="text-primary font-bold text-xs sm:text-base px-1 cursor-pointer" :icon="['fas', 'angle-double-right']" @click="changeLastPage()"/>
       </div>
     </div>
   </div>

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -11,21 +11,21 @@
       <div class="text-white text-sm pl-4 min-w-36 md:text-xl">문제를 맞춰라</div>
     </div>
     <div class="w-full h-auto bg-white pt-4 md:pt-10 pb-3">
-      <div class="flex pb-2 sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
-        <div class="md:w-2/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none text-white">0</div>
+      <div class="flex justify-center pb-2 w-full sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
+        <div class="md:w-1/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none text-white">0</div>
         <div class="w-3/12 flex justify-center text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center sm:min-w-40 select-none pl-1">닉네임</div>
-        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-40 flex justify-center items-center sm:min-w-48 select-none">맞춘 문제</div>
+        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-40 flex justify-center items-center sm:min-w-72 select-none">맞춘 문제</div>
         <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">총점</div>
       </div>
-      <div v-for="(user, index) in this.rankData" :key="user.quizRankId">
-        <div class="flex pb-4 md:pb-7">
-          <div class="w-10 sm:min-w-10 flex justify-center pl-2 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
+      <div v-for="(user, index) in this.rankData" :key="user.quizRankId" class="w-full">
+        <div class="flex justify-center pb-4 md:pb-7">
+          <div class="md:w-1/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
             <div :class=this.rankColor(this.getRank(index))>
               {{ this.getRank(index) }}
             </div>
           </div>
           <div class="w-3/12 flex justify-center sm:min-w-40 items-center pl-1 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
-          <div class="w-40 sm:min-w-48 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
+          <div class="w-40 sm:min-w-72 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
             <div class="flex gap-2 select-none">
               <div>넌센스</div>
               <div class="flex">

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -1,31 +1,31 @@
 <template>
-  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center pr-0 md:pr-4">
-    <div class="w-30 h-10 ml-20"></div>
+  <div class="flex w-full h-24 bg-white justify-between items-center">
+    <div class="w-30 h-20 ml-10"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
+      <img src="/image/logo.png" class="w-30 h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
+    <div class="text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
-    <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">
-      <div class="text-white text-sm pl-4 min-w-36 md:text-xl">문제를 맞춰라</div>
+    <div class="w-full h-14 min-h-8 flex items-center select-none">
+      <div class="text-white text-xl pl-4 min-w-36">문제를 맞춰라</div>
     </div>
-    <div class="w-full h-auto bg-white pt-4 md:pt-10 pb-3">
-      <div class="flex justify-center pb-2 w-full sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
-        <div class="md:w-1/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none text-white">0</div>
-        <div class="w-3/12 flex justify-center text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center min-w-24 select-none pl-1">닉네임</div>
-        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-40 flex justify-center items-center min-w-40 select-none">맞춘 문제</div>
-        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">총점</div>
+    <div class="w-full h-auto bg-white pt-10 pb-3">
+      <div class="flex pb-2 sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
+        <div class="w-2/12 min-w-10 px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20"></div>
+        <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-3/12 items-center min-w-40 pl-2 select-none">닉네임</div>
+        <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-4/12 flex justify-center items-center min-w-48 select-none">맞춘 문제</div>
+        <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">총점</div>
       </div>
-      <div v-for="(user, index) in this.rankData" :key="user.quizRankId" class="w-full">
-        <div class="flex justify-center pb-4 md:pb-7">
-          <div class="md:w-1/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
+      <div v-for="(user, index) in this.rankData" :key="user.quizRankId">
+        <div class="flex pb-4 md:pb-7">
+          <div class="w-2/12 min-w-10 flex justify-end px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
             <div :class=this.rankColor(this.getRank(index))>
               {{ this.getRank(index) }}
             </div>
           </div>
-          <div class="w-3/12 flex justify-center min-w-24 items-center pl-1 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
-          <div class="min-w-40 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
+          <div class="w-3/12 min-w-40 items-center pl-1 text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">{{ user.userName }}</div>
+          <div class="w-4/12 min-w-48 flex gap-2 justify-center text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
             <div class="flex gap-2 select-none">
               <div>넌센스</div>
               <div class="flex">
@@ -42,7 +42,7 @@
               </div>
             </div>
           </div>
-          <div class="w-2/12 flex justify-center items-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl min-w-16 gap-1 select-none">
+          <div class="w-2/12 flex justify-center items-center text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl min-w-16 gap-1 select-none">
             <div>{{ user.allCorrect }}</div>
             <div>/</div>
             <div>10</div>
@@ -50,20 +50,20 @@
         </div>
       </div>
       <div class="select-none flex items-center justify-center text-sm md:text-lg lg:text-xl">
-        <font-awesome-icon class="svg-inline--fa fa-angles-left text-primary text-xs sm:text-base px-1 font-bold cursor-pointer" :icon="['fas', 'angle-double-left']" @click="changeFirstPage()"/>
-        <font-awesome-icon class="svg-inline--fa fa-angle-left text-primary text-xs sm:text-base pr-2 pl-1 font-bold cursor-pointer" :icon="['fas', 'angle-left']" @click="decressePageNumber()"/>
-        <div v-if="showStartEllipsis" class="text-white w-4 h-4 sm:w-7 sm:h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changeFirstPage()">1</div>
-        <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-xs sm:text-base">...</div>
+        <font-awesome-icon class="text-primary text-base px-1 font-bold cursor-pointer" :icon="['fas', 'angle-double-left']" @click="changeFirstPage()"/>
+        <font-awesome-icon class="text-primary text-base pr-2 pl-1 font-bold cursor-pointer" :icon="['fas', 'angle-left']" @click="decressePageNumber()"/>
+        <div v-if="showStartEllipsis" class="text-primary px-2 font-bold text-base cursor-pointer" @click="changeFirstPage()">1</div>
+        <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-base">...</div>
         <div v-for="(page, index) in pages" :key="index">
-          <div class="text-white w-4 h-4 sm:w-7 sm:h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changePage(page)">
+          <div class="text-white w-7 h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-base cursor-pointer" @click="changePage(page)">
             <div class="text-primary font-bold bg-white w-7 h-7 flex justify-center items-center" v-if="currentPage != page">{{ page }}</div>
             <div v-else>{{ page }}</div>
           </div>
         </div>
-        <div v-if="showEndEllipsis" class="text-primary font-bold px-1 text-xs sm:text-base">...</div>
-        <div v-if="showEndEllipsis" class="text-primary font-bold px-2 text-xs sm:text-base cursor-pointer" @click="changeLastPage()">{{ this.pageCount }}</div>
-        <font-awesome-icon class="text-primary font-bold text-xs sm:text-base pr-1 pl-2 cursor-pointer" :icon="['fas', 'angle-right']" @click="increasePageNumber()"/>
-        <font-awesome-icon class="text-primary font-bold text-xs sm:text-base px-1 cursor-pointer" :icon="['fas', 'angle-double-right']" @click="changeLastPage()"/>
+        <div v-if="showEndEllipsis" class="text-primary font-bold px-1 text-base">...</div>
+        <div v-if="showEndEllipsis" class="text-primary font-bold px-2 text-base cursor-pointer" @click="changeLastPage()">{{ this.pageCount }}</div>
+        <font-awesome-icon class="text-primary font-bold text-base pr-1 pl-2 cursor-pointer" :icon="['fas', 'angle-right']" @click="increasePageNumber()"/>
+        <font-awesome-icon class="text-primary font-bold text-base px-1 cursor-pointer" :icon="['fas', 'angle-double-right']" @click="changeLastPage()"/>
       </div>
     </div>
   </div>

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center pr-0 md:pr-4">
     <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
       <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -4,7 +4,7 @@
     <div class="flex justify-center select-none">
       <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
+    <div class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
     <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex w-full h-24 bg-white justify-between items-center">
-    <div class="w-30 h-20 ml-10"></div>
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center pr-0 md:pr-4">
+    <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-20 cursor-pointer" @click="handleRouterMain()"/>
+      <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
     <div class="w-full h-14 min-h-8 flex items-center select-none">

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
-    <div class="w-30 sm:h-20 ml-20"></div>
+    <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
       <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="text-xs text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
     <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex w-full h-24 bg-white justify-between items-center">
-    <div class="w-30 h-20 ml-10"></div>
+    <div class="w-30 h-20 ml-20"></div>
     <div class="flex justify-center select-none">
       <img src="/image/logo.png" class="w-30 h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>

--- a/src/components/QuizStatisticPage.vue
+++ b/src/components/QuizStatisticPage.vue
@@ -2,9 +2,9 @@
   <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
     <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
+      <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
     <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">
@@ -13,8 +13,8 @@
     <div class="w-full h-auto bg-white pt-4 md:pt-10 pb-3">
       <div class="flex justify-center pb-2 w-full sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
         <div class="md:w-1/12 sm:min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none text-white">0</div>
-        <div class="w-3/12 flex justify-center text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center sm:min-w-40 select-none pl-1">닉네임</div>
-        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-40 flex justify-center items-center sm:min-w-72 select-none">맞춘 문제</div>
+        <div class="w-3/12 flex justify-center text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center min-w-24 select-none pl-1">닉네임</div>
+        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-40 flex justify-center items-center min-w-40 select-none">맞춘 문제</div>
         <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">총점</div>
       </div>
       <div v-for="(user, index) in this.rankData" :key="user.quizRankId" class="w-full">
@@ -24,8 +24,8 @@
               {{ this.getRank(index) }}
             </div>
           </div>
-          <div class="w-3/12 flex justify-center sm:min-w-40 items-center pl-1 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
-          <div class="w-40 sm:min-w-72 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
+          <div class="w-3/12 flex justify-center min-w-24 items-center pl-1 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
+          <div class="min-w-40 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
             <div class="flex gap-2 select-none">
               <div>넌센스</div>
               <div class="flex">

--- a/src/components/TimerStatisticPage.vue
+++ b/src/components/TimerStatisticPage.vue
@@ -37,7 +37,7 @@
         <div v-if="showStartEllipsis" class="text-primary px-2 font-bold text-xs sm:text-base cursor-pointer" @click="changeFirstPage()">1</div>
         <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-xs sm:text-base">...</div>
         <div v-for="(page, index) in pages" :key="index">
-          <div class="text-white w-7 h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changePage(page)">
+          <div class="text-white w-4 h-4 sm:w-7 sm:h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changePage(page)">
             <div class="text-primary font-bold bg-white w-7 h-7 flex justify-center items-center" v-if="currentPage != page">{{ page }}</div>
             <div v-else>{{ page }}</div>
           </div>

--- a/src/components/TimerStatisticPage.vue
+++ b/src/components/TimerStatisticPage.vue
@@ -1,54 +1,54 @@
 <template>
-  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center pr-0 md:pr-4">
     <div class="w-30 h-10 ml-20"></div>
     <div class="flex justify-center select-none">
-      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
+      <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
-    <div class="w-full h-14 min-h-8 flex items-center select-none">
-      <div class="text-white text-xl pl-4 min-w-36">정각을 맞춰라</div>
+    <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">
+      <div class="text-white text-sm pl-4 min-w-36 md:text-xl">정각을 맞춰라</div>
     </div>
-      <div class="w-full h-auto bg-white pt-10 pb-3">
-        <div class="flex pb-2 sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
-          <div class="w-3/12 min-w-10 px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20"></div>
-          <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-3/12 items-center min-w-40 pl-2 select-none">닉네임</div>
-          <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-3/12 flex justify-center items-center min-w-40 select-none">기록 / 목표 시간</div>
-          <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-1/12 flex justify-center items-center min-w-14 select-none">오차</div>
-        </div>
-        <div v-for="(user, index) in this.rankData" :key="user.quizRankId">
-          <div class="flex pb-4 md:pb-7">
-            <div class="w-3/12 min-w-10 flex justify-end px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 items-center text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold select-none">
-              <div :class=this.rankColor(this.getRank(index))>{{ this.getRank(index) }}</div>
-            </div>
-            <div class="w-3/12 min-w-40 items-center pl-1 text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
-            <div class="w-3/12 min-w-40 flex gap-3 justify-center text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center select-none">
-              <div>{{ user.stopTime }}</div>
-              <div>/</div>
-              <div>{{ user.targetTime }}</div>
-            </div>
-            <div class="w-1/12 flex justify-center items-center text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl min-w-14 select-none">{{ user.errorRange }}</div>
+    <div class="w-full h-auto bg-white pt-10 pb-3 px-2">
+      <div class="flex justify-center pb-2 sm:pb-4 md:pb-6 lg:pb-8 xl:pb-10">
+        <div class="w-1/12 min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none text-white">0</div>
+        <div class="w-3/12 flex justify-center text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center min-w-24 select-none pl-1">닉네임</div>
+        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold flex justify-center items-center min-w-40 select-none">기록 / 목표 시간</div>
+        <div class="text-light-purple text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-2/12 flex justify-center items-center min-w-16 select-none">오차</div>
+      </div>
+      <div v-for="(user, index) in this.rankData" :key="user.quizRankId" class="w-full">
+        <div class="flex justify-center pb-4 md:pb-7">
+          <div class="w-1/12 min-w-10 flex justify-start px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold items-center select-none">
+            <div :class=this.rankColor(this.getRank(index))>{{ this.getRank(index) }}</div>
           </div>
-        </div>
-        <div v-if="showPagination" class="select-none flex items-center justify-center text-sm md:text-lg lg:text-xl">
-          <font-awesome-icon class="text-primary text-base px-1 font-bold cursor-pointer" :icon="['fas', 'angle-double-left']" @click="changeFirstPage()"/>
-          <font-awesome-icon class="text-primary text-base pr-2 pl-1 font-bold cursor-pointer" :icon="['fas', 'angle-left']" @click="decressePageNumber()"/>
-          <div v-if="showStartEllipsis" class="text-primary px-2 font-bold text-base cursor-pointer" @click="changeFirstPage()">1</div>
-          <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-base">...</div>
-          <div v-for="(page, index) in pages" :key="index">
-            <div class="text-white w-7 h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-base cursor-pointer" @click="changePage(page)">
-              <div class="text-primary font-bold bg-white w-7 h-7 flex justify-center items-center" v-if="currentPage != page">{{ page }}</div>
-              <div v-else>{{ page }}</div>
-            </div>
+          <div class="w-3/12 flex justify-center min-w-24 items-center pl-1 text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl select-none">alswlfjddl</div>
+          <div class="min-w-40 flex gap-2 justify-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl items-center">
+            <div>{{ user.stopTime }}</div>
+            <div>/</div>
+            <div>{{ user.targetTime }}</div>
           </div>
-          <div v-if="showEndEllipsis" class="text-primary font-bold px-1 text-base">...</div>
-          <div v-if="showEndEllipsis" class="text-primary font-bold px-2 text-base cursor-pointer" @click="changeLastPage()">{{ this.pageCount }}</div>
-          <font-awesome-icon class="text-primary font-bold text-base pr-1 pl-2 cursor-pointer" :icon="['fas', 'angle-right']" @click="increasePageNumber()"/>
-          <font-awesome-icon class="text-primary font-bold text-base px-1 cursor-pointer" :icon="['fas', 'angle-double-right']" @click="changeLastPage()"/>
+          <div class="w-2/12 flex justify-center items-center text-xs sm:text-lg md:text-xl lg:text-2xl xl:text-3xl min-w-16 gap-1 select-none">{{ user.errorRange }}</div>
         </div>
       </div>
+      <div v-if="showPagination" class="select-none flex items-center justify-center text-sm md:text-lg lg:text-xl">
+        <font-awesome-icon class="text-primary text-xs sm:text-base px-1 font-bold cursor-pointer" :icon="['fas', 'angle-double-left']" @click="changeFirstPage()"/>
+        <font-awesome-icon class="text-primary text-xs sm:text-base pr-2 pl-1 font-bold cursor-pointer" :icon="['fas', 'angle-left']" @click="decressePageNumber()"/>
+        <div v-if="showStartEllipsis" class="text-primary px-2 font-bold text-xs sm:text-base cursor-pointer" @click="changeFirstPage()">1</div>
+        <div v-if="showStartEllipsis" class="text-primary px-1 font-bold text-xs sm:text-base">...</div>
+        <div v-for="(page, index) in pages" :key="index">
+          <div class="text-white w-7 h-7 flex justify-center items-center font-bold bg-light-purple rounded-2xl text-xs sm:text-base cursor-pointer" @click="changePage(page)">
+            <div class="text-primary font-bold bg-white w-7 h-7 flex justify-center items-center" v-if="currentPage != page">{{ page }}</div>
+            <div v-else>{{ page }}</div>
+          </div>
+        </div>
+        <div v-if="showEndEllipsis" class="text-primary font-bold px-1 text-xs sm:text-base">...</div>
+        <div v-if="showEndEllipsis" class="text-primary font-bold px-2 text-xs sm:text-base cursor-pointer" @click="changeLastPage()">{{ this.pageCount }}</div>
+        <font-awesome-icon class="text-primary font-bold text-xs sm:text-base pr-1 pl-2 cursor-pointer" :icon="['fas', 'angle-right']" @click="increasePageNumber()"/>
+        <font-awesome-icon class="text-primary font-bold text-xs sm:text-base px-1 cursor-pointer" :icon="['fas', 'angle-double-right']" @click="changeLastPage()"/>
+      </div>
     </div>
+  </div>
   <CommentPage></CommentPage>
 </template>
   

--- a/src/components/TimerStatisticPage.vue
+++ b/src/components/TimerStatisticPage.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex w-full h-24 bg-white justify-between items-center">
-    <div class="w-30 h-20 ml-20"></div>
-    <div class="flex justify-center">
-      <img src="/image/logo.png" class="w-30 h-20 cursor-pointer select-none" @click="handleRouterMain()"/>
+  <div class="flex w-full h-16 sm:h-24 bg-white justify-between items-center">
+    <div class="w-30 h-10 ml-20"></div>
+    <div class="flex justify-center select-none">
+      <img src="/image/logo.png" class="w-30 h-14 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
+    <div class="w-16 text-xs sm:text-lg text-light-purple order-last flex justify-center mr-10 font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
     <div class="w-full h-14 min-h-8 flex items-center select-none">

--- a/src/components/TimerStatisticPage.vue
+++ b/src/components/TimerStatisticPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex w-full h-24 bg-white justify-between items-center">
-    <div class="w-30 h-20 ml-10"></div>
+    <div class="w-30 h-20 ml-20"></div>
     <div class="flex justify-center">
       <img src="/image/logo.png" class="w-30 h-20 cursor-pointer select-none" @click="handleRouterMain()"/>
     </div>
@@ -17,7 +17,7 @@
           <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-3/12 flex justify-center items-center min-w-40 select-none">기록 / 목표 시간</div>
           <div class="text-light-purple text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold w-1/12 flex justify-center items-center min-w-14 select-none">오차</div>
         </div>
-        <div v-for="(user, index) in this.rankData" key="user.quizRankId">
+        <div v-for="(user, index) in this.rankData" :key="user.quizRankId">
           <div class="flex pb-4 md:pb-7">
             <div class="w-3/12 min-w-10 flex justify-end px-4 sm:px-8 md:px-10 lg:px-14 xl:px-20 items-center text-lg sm:text-lg md:text-xl lg:text-2xl xl:text-3xl font-bold select-none">
               <div :class=this.rankColor(this.getRank(index))>{{ this.getRank(index) }}</div>

--- a/src/components/TimerStatisticPage.vue
+++ b/src/components/TimerStatisticPage.vue
@@ -4,7 +4,7 @@
     <div class="flex justify-center select-none">
       <img src="/image/logo.png" class="w-30 h-14 min-h-14 min-w-16 sm:h-20 cursor-pointer" @click="handleRouterMain()"/>
     </div>
-    <div class="w-32 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
+    <div class="w-20 text-xs sm:text-lg text-light-purple order-last flex justify-center font-medium cursor-pointer select-none">Login</div>
   </div>
   <div class="flex flex-col h-auto w-full bg-primary">
     <div class="w-full h-10 md:h-14 min-h-8 flex items-center select-none">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,16 @@ module.exports = {
       '16': '16px',
       '24': '24px'
     },
+    fontSize: {
+      'sm': '0.8rem',
+      'base': '1rem',
+      'xl': '1.25rem',
+      '2xl': '1.563rem',
+      '3xl': '1.953rem',
+      '4xl': '2.441rem',
+      '5xl': '3.052rem',
+      'favortire-default-title': '0.625rem'
+    }
   },
   plugins: [
   ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,10 @@ module.exports = {
       '3xl': '1.953rem',
       '4xl': '2.441rem',
       '5xl': '3.052rem',
+      '6xl': '3.75rem',
+      '7xl': '4.5rem',
+      '8xl': '6rem',
+      '9xl': '8rem',
       'favortire-default-title': '0.625rem'
     }
   },


### PR DESCRIPTION
## [ page ]
### main page
<img width="300" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/93eb810a-940b-4b34-b1f0-d3436f013b7f">

### favorite page
<img width="300" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/7abda38d-3397-4f54-9de5-5e49e807c97b">
<img width="300" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/471ac03b-019a-4625-bfdc-aae85258d243">

### statistic page
#### favorite
<img width="300" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/03d009e1-9e32-4b7c-b487-335c9f544dfb">

#### timer
<img width="300" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/2d197b7a-e5ea-4a79-bbf9-65993467fafd">

#### quiz
<img width="300" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/bef6e8d7-b22e-42f8-ac0a-afaad07c2fb1">

### header
<img width="553" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/29f8db2f-6414-4bce-922b-a7e2ccd7ea91">

## favorite game final round error
### before
<img width="553" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/f8c368e7-3d8e-436e-97cf-5c969c0d1ebd">

### after
<img width="553" alt="image" src="https://github.com/DEV-TINO/PLAY-TINO-FE/assets/59122931/be019fd2-64f3-4033-b19e-d2e2320ca5e2">

## check list
- [x] main page
- [x] delete main page mouseover animation
- [x] favorite page
- [x] favorite page animation (select title size)
- [x] favorite statistic page
- [x] timer statistic page
- [x] quiz statistic page
- [x] header
- [x] fix favorite game final round error